### PR TITLE
test prereqs should be declared in the "test" phase, not "build"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+
+        - fix phase for test prerequisites
+
 0.08 2018-11-01
         - Change permissions for files (manwar++).
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ WriteMakefile(
   AUTHOR       => 'Nils Diewald',
   ABSTRACT     => 'Generate Secure Random Strings for Mojolicious',
   VERSION_FROM => 'lib/Mojolicious/Plugin/Util/RandomString.pm',
-  BUILD_REQUIRES => {
+  TEST_REQUIRES => {
     'Test::More' => 0,
     'Test::Memory::Cycle' => '1.06'
   },


### PR DESCRIPTION
Some cpan clients (e.g. carton, cpanm) know how to skip test
prerequisites when installing in an environment where tests are not run